### PR TITLE
Typo and target changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,10 +163,10 @@
 								<a href="">Forms</a>
 							</li>
 							<li>
-								<a href="https://www.eproc.punjab.gov.in">Tenders</a>
+								<a href="https://www.eproc.punjab.gov.in" target="_blank">Tenders</a>
 							</li>
 							<li>
-								<a href="http://punjab.gov.in/">E-gazzete</a>
+								<a href="http://punjab.gov.in/" target="_blank">E-Gazzette</a>
 							</li>
                         </ul>
                         <!-- End Navigation List -->


### PR DESCRIPTION
1. E-Gazette now has proper spellings on index.html

2. E-Gazette and Tenders should now open in new tab.

Fixes #22 